### PR TITLE
🚧 使用言語一覧の配列にnullが混じっていれば　その他　とする

### DIFF
--- a/src/components/userInfo/Chart.tsx
+++ b/src/components/userInfo/Chart.tsx
@@ -13,7 +13,6 @@ interface UseRate {
 
 export const Chart: React.FC<Props> = (props: Props) => {
   const useRate = props.useRate;
-  console.log(useRate);
 
   return (
     <PieChart width={400} height={400}>

--- a/src/components/userInfo/ChartArea.tsx
+++ b/src/components/userInfo/ChartArea.tsx
@@ -22,7 +22,7 @@ const calculateLanguageUseRate = (langs: string[]): UseRate[] => {
     //TODO　重複をけす
     useRate.push({
       id: uuid.v4(),
-      language: lang,
+      language: lang !== null ? lang : 'その他',
       rate: Math.floor(rate * 100) / 100,
     });
   }
@@ -42,6 +42,7 @@ const calculateLanguageUseRate = (langs: string[]): UseRate[] => {
 
 export const ChartArea: React.FC<Props> = (props: Props) => {
   const langs = props.languages;
+  console.log(langs);
   const useRate = calculateLanguageUseRate(langs);
 
   //無効なユーザー名ならChartは表示させない


### PR DESCRIPTION
nullだとグラフの名前が表示されないため